### PR TITLE
Cleaning unnecessary widgets and variables

### DIFF
--- a/lib/data.dart
+++ b/lib/data.dart
@@ -1,33 +1,27 @@
-import 'package:flutter/material.dart';
+import 'dart:ui';
 
 var pageList = [
   PageModel(
       imageUrl: "assets/illustration.png",
       title: "MUSIC",
       body: "EXPERIENCE WICKED PLAYLISTS",
-      titleGradient: gradients[0]),
+      titleGradient: [Color(0xFF9708CC), Color(0xFF43CBFF)]),
   PageModel(
       imageUrl: "assets/illustration2.png",
       title: "SPA",
       body: "FEEL THE MAGIC OF WELLNESS",
-      titleGradient: gradients[1]),
+      titleGradient: [Color(0xFFE2859F), Color(0xFFFCCF31)]),
   PageModel(
       imageUrl: "assets/illustration3.png",
       title: "TRAVEL",
       body: "LET'S HIKE UP",
-      titleGradient: gradients[2]),
-];
-
-List<List<Color>> gradients = [
-  [Color(0xFF9708CC), Color(0xFF43CBFF)],
-  [Color(0xFFE2859F), Color(0xFFFCCF31)],
-  [Color(0xFF5EFCE8), Color(0xFF736EFE)],
+      titleGradient: [Color(0xFF5EFCE8), Color(0xFF736EFE)]),
 ];
 
 class PageModel {
-  var imageUrl;
-  var title;
-  var body;
+  String imageUrl;
+  String title;
+  String body;
   List<Color> titleGradient = [];
   PageModel({this.imageUrl, this.title, this.body, this.titleGradient});
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,13 +10,13 @@ void main() => runApp(MaterialApp(
 
 class MyApp extends StatefulWidget {
   @override
-  _MyAppState createState() => new _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> with TickerProviderStateMixin {
   PageController _controller;
   int currentPage = 0;
-  bool lastPage = false;
+  bool isLastPage = false;
   AnimationController animationController;
   Animation<double> _scaleAnimation;
 
@@ -50,7 +50,7 @@ class _MyAppState extends State<MyApp> with TickerProviderStateMixin {
       ),
       child: Scaffold(
         backgroundColor: Colors.transparent,
-        body: new Stack(
+        body: Stack(
           fit: StackFit.expand,
           children: <Widget>[
             PageView.builder(
@@ -59,105 +59,35 @@ class _MyAppState extends State<MyApp> with TickerProviderStateMixin {
               onPageChanged: (index) {
                 setState(() {
                   currentPage = index;
-                  if (currentPage == pageList.length - 1) {
-                    lastPage = true;
+                  isLastPage = currentPage == pageList.length - 1;
+                  if (isLastPage) {
                     animationController.forward();
                   } else {
-                    lastPage = false;
                     animationController.reset();
                   }
-                  print(lastPage);
                 });
+                print(isLastPage);
               },
-              itemBuilder: (context, index) {
-                return AnimatedBuilder(
-                  animation: _controller,
-                  builder: (context, child) {
-                    var page = pageList[index];
-                    var delta;
-                    var y = 1.0;
-
-                    if (_controller.position.haveDimensions) {
-                      delta = _controller.page - index;
-                      y = 1 - delta.abs().clamp(0.0, 1.0);
-                    }
-                    return Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: <Widget>[
-                        Image.asset(page.imageUrl),
-                        Container(
-                          margin: EdgeInsets.only(left: 12.0),
-                          height: 100.0,
-                          child: Stack(
-                            children: <Widget>[
-                              Opacity(
-                                opacity: .10,
-                                child: GradientText(
-                                  page.title,
-                                  gradient: LinearGradient(
-                                      colors: pageList[index].titleGradient),
-                                  style: TextStyle(
-                                      fontSize: 100.0,
-                                      fontFamily: "Montserrat-Black",
-                                      letterSpacing: 1.0),
-                                ),
-                              ),
-                              Padding(
-                                padding: EdgeInsets.only(top: 30.0, left: 22.0),
-                                child: GradientText(
-                                  page.title,
-                                  gradient: LinearGradient(
-                                      colors: pageList[index].titleGradient),
-                                  style: TextStyle(
-                                    fontSize: 70.0,
-                                    fontFamily: "Montserrat-Black",
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.only(left: 34.0, top: 12.0),
-                          child: Transform(
-                            transform:
-                                Matrix4.translationValues(0, 50.0 * (1 - y), 0),
-                            child: Text(
-                              page.body,
-                              style: TextStyle(
-                                  fontSize: 20.0,
-                                  fontFamily: "Montserrat-Medium",
-                                  color: Color(0xFF9B9B9B)),
-                            ),
-                          ),
-                        )
-                      ],
-                    );
-                  },
-                );
-              },
+              itemBuilder: (context, index) => AnimatedBuilder(
+                    animation: _controller,
+                    builder: (context, child) => animatedPageViewBuilder(index),
+                  ),
             ),
             Positioned(
               left: 30.0,
               bottom: 55.0,
-              child: Container(
-                  width: 160.0,
-                  child: PageIndicator(currentPage, pageList.length)),
+              width: 160.0,
+              child: PageIndicator(currentPage, pageList.length),
             ),
             Positioned(
               right: 30.0,
               bottom: 30.0,
               child: ScaleTransition(
                 scale: _scaleAnimation,
-                child: lastPage
+                child: isLastPage
                     ? FloatingActionButton(
                         backgroundColor: Colors.white,
-                        child: Icon(
-                          Icons.arrow_forward,
-                          color: Colors.black,
-                        ),
+                        child: Icon(Icons.arrow_forward, color: Colors.black),
                         onPressed: () {},
                       )
                     : Container(),
@@ -166,6 +96,64 @@ class _MyAppState extends State<MyApp> with TickerProviderStateMixin {
           ],
         ),
       ),
+    );
+  }
+
+  Widget animatedPageViewBuilder(int index) {
+    PageModel page = pageList[index];
+    double delta;
+    double y = 1.0;
+
+    if (_controller.position.haveDimensions) {
+      delta = _controller.page - index;
+      y = delta.abs().clamp(0.0, 1.0);
+    }
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Image.asset(page.imageUrl),
+        Container(
+          margin: EdgeInsets.only(left: 12.0),
+          height: 100.0,
+          child: Stack(
+            children: <Widget>[
+              Opacity(
+                opacity: .10,
+                child: GradientText(
+                  page.title,
+                  gradient: LinearGradient(colors: page.titleGradient),
+                  style: TextStyle(
+                      fontSize: 100.0,
+                      fontFamily: "Montserrat-Black",
+                      letterSpacing: 1.0),
+                ),
+              ),
+              Padding(
+                padding: EdgeInsets.only(top: 30.0, left: 22.0),
+                child: GradientText(
+                  page.title,
+                  gradient: LinearGradient(colors: page.titleGradient),
+                  style:
+                      TextStyle(fontSize: 70.0, fontFamily: "Montserrat-Black"),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Container(
+          padding: const EdgeInsets.only(left: 34.0, top: 12.0),
+          transform: Matrix4.translationValues(0, 50.0 * y, 0),
+          child: Text(
+            page.body,
+            style: TextStyle(
+                fontSize: 20.0,
+                fontFamily: "Montserrat-Medium",
+                color: Color(0xFF9B9B9B)),
+          ),
+        )
+      ],
     );
   }
 }

--- a/lib/page_indicator.dart
+++ b/lib/page_indicator.dart
@@ -5,38 +5,25 @@ class PageIndicator extends StatelessWidget {
   final int pageCount;
   PageIndicator(this.currentIndex, this.pageCount);
 
-  _indicator(bool isActive) {
+  Widget _indicator(int index) {
     return Expanded(
-      child: Padding(
-        padding: EdgeInsets.symmetric(horizontal: 4.0),
-        child: Container(
-          height: 4.0,
-          decoration: BoxDecoration(
-              color: isActive ? Colors.white : Color(0xFF3E4750),
-              boxShadow: [
-                BoxShadow(
-                    color: Colors.black12,
-                    offset: Offset(0.0, 2.0),
-                    blurRadius: 2.0)
-              ]),
-        ),
+      child: Container(
+        margin: EdgeInsets.symmetric(horizontal: 4.0),
+        height: 4.0,
+        decoration: BoxDecoration(
+            color: index == currentIndex ? Colors.white : Color(0xFF3E4750),
+            boxShadow: [
+              BoxShadow(
+                  color: Colors.black12,
+                  offset: Offset(0.0, 2.0),
+                  blurRadius: 2.0)
+            ]),
       ),
     );
   }
 
-  _buildPageIndicators() {
-    List<Widget> indicatorList = [];
-    for (int i = 0; i < pageCount; i++) {
-      indicatorList
-          .add(i == currentIndex ? _indicator(true) : _indicator(false));
-    }
-    return indicatorList;
-  }
+  List<Widget> _buildPageIndicators() => List.generate(pageCount, _indicator);
 
   @override
-  Widget build(BuildContext context) {
-    return new Row(
-      children: _buildPageIndicators(),
-    );
-  }
+  Widget build(BuildContext context) => Row(children: _buildPageIndicators());
 }


### PR DESCRIPTION
For example:
```
Padding(
  padding: EdgeInsets.only(...),
  child: Transform(
    transform: Matrix4.translationValues(...),
    child: someChild
  )
)
```

can be rewritten as:
```
Container(
  padding: EdgeInsets.only(...),
  transform: Matrix4.translationValues(...),
  child: someChild
)
```

All modifications are similar.